### PR TITLE
Distinguish processing of storages from other resources

### DIFF
--- a/resource/network/processor.go
+++ b/resource/network/processor.go
@@ -23,6 +23,25 @@ func CreateProcessor(Reader *reader.Reader) *Processor {
 	}
 }
 
+// Process provides listing of the networks with pagination.
+func (p *Processor) Process(read chan resource.Resource, readDone chan bool, swg *sizedwaitgroup.SizedWaitGroup) {
+	defer swg.Done()
+	pageOffset := 1
+
+processing:
+	for {
+		swg.Add()
+		go p.List(read, readDone, swg, pageOffset)
+		select {
+		case <-readDone:
+			break processing
+		default:
+		}
+
+		pageOffset++
+	}
+}
+
 // List calls method to list virtual networks by page offset.
 func (p *Processor) List(read chan resource.Resource, readDone chan bool, swg *sizedwaitgroup.SizedWaitGroup,
 	pageOffset int) {

--- a/resource/storage/processor.go
+++ b/resource/storage/processor.go
@@ -23,18 +23,21 @@ func CreateProcessor(Reader *reader.Reader) *Processor {
 	}
 }
 
+// Process provides listing of the storages once.
+func (p *Processor) Process(read chan resource.Resource, readDone chan bool, swg *sizedwaitgroup.SizedWaitGroup) {
+	defer swg.Done()
+
+	swg.Add()
+	go p.List(read, readDone, swg, 0)
+}
+
 // List calls method to list all images.
-func (p *Processor) List(read chan resource.Resource, readDone chan bool, swg *sizedwaitgroup.SizedWaitGroup, _ int) {
+func (p *Processor) List(read chan resource.Resource, _ chan bool, swg *sizedwaitgroup.SizedWaitGroup, _ int) {
 	defer swg.Done()
 
 	images, err := p.reader.ListAllImages()
 	if err != nil {
 		log.WithFields(log.Fields{"error": err}).Fatal("error list images")
-	}
-
-	if len(images) == 0 {
-		readDone <- true
-		return
 	}
 
 	for _, v := range images {

--- a/resource/virtualmachine/processor.go
+++ b/resource/virtualmachine/processor.go
@@ -23,6 +23,25 @@ func CreateProcessor(Reader *reader.Reader) *Processor {
 	}
 }
 
+// Process provides listing of the virtual machines with pagination.
+func (p *Processor) Process(read chan resource.Resource, readDone chan bool, swg *sizedwaitgroup.SizedWaitGroup) {
+	defer swg.Done()
+	pageOffset := 1
+
+processing:
+	for {
+		swg.Add()
+		go p.List(read, readDone, swg, pageOffset)
+		select {
+		case <-readDone:
+			break processing
+		default:
+		}
+
+		pageOffset++
+	}
+}
+
 // List calls method to list virtual machines by page offset.
 func (p *Processor) List(read chan resource.Resource, readDone chan bool, swg *sizedwaitgroup.SizedWaitGroup,
 	pageOffset int) {


### PR DESCRIPTION
All storages are listed in one call because OpenNebula does not support pagination for storages. It needs to be processed differently than resources with pagination (virtual machines and networks).

This PR adds methods to list virtual machines and networks with pagination and method to list all storages in one call. It fixes the previous listing to provide it using these new methods.